### PR TITLE
Add ca-certificates to Dockerfile for SSL/TLS certificate verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy project files


### PR DESCRIPTION
## Problem

The `python:3.11-slim` base image used in the Dockerfile is minimal and doesn't include the `ca-certificates` package by default. This causes SSL/TLS certificate verification failures when the Docker container tries to connect to Comet's servers over HTTPS.

## Solution

Added `ca-certificates` to the system dependencies in the Dockerfile. This package provides the CA certificate bundle (`/etc/ssl/certs/ca-certificates.crt`) that Python's `requests` library and other HTTPS clients use for certificate verification.

## Changes

- Added `ca-certificates` to the `apt-get install` command alongside `gcc`
- Maintains the existing pattern of installing dependencies in a single RUN command with cleanup

## Testing

This change ensures that HTTPS connections to Comet's servers will properly verify SSL certificates, preventing connection errors in the Docker container.