### PR TITLE
Add get_experiment_output tool for retrieving raw training logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ export COMET_WORKSPACE=your_workspace_name
 - **`list_experiments(workspace, project_name)`** - List recent experiments with optional filtering
 - **`get_experiment_details(experiment_id)`** - Get comprehensive experiment information including metrics and parameters
 - **`get_experiment_code(experiment_id)`** - Retrieve source code from experiments
+- **`get_experiment_output(experiment_id)`** - Get raw training logs (stdout/stderr) from experiments
 - **`get_experiment_metric_data(experiment_ids, metric_names, x_axis)`** - Get metric data for multiple experiments
 - **`get_default_workspace()`** - Get the default workspace name for the current user
 - **`list_projects(workspace)`** - List all projects in a workspace

--- a/comet_mcp/tools.py
+++ b/comet_mcp/tools.py
@@ -240,6 +240,23 @@ def get_experiment_code(experiment_id: str) -> Dict[str, str]:
 
 
 @_instrument_tool
+def get_experiment_output(experiment_id: str) -> Dict[str, str]:
+    """
+    Get the raw training logging (stdout/stderr) for a specific experiment.
+
+    Args:
+        experiment_id: The ID of the experiment to retrieve
+
+    Returns:
+        Dictionary containing:
+        - output: String containing the complete stdout/stderr output that was logged for this experiment
+    """
+    with get_comet_api() as api:
+        experiment = api.get_experiment_by_key(experiment_id)
+        return {"output": experiment.get_output()}
+
+
+@_instrument_tool
 def get_experiment_metric_data(
     experiment_ids: List[str], metric_names: List[str], x_axis: Optional[str] = None
 ) -> Dict[str, Any]:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -17,6 +17,8 @@ from comet_mcp.tools import (
     get_session_info,
     get_experiment_metric_data,
     get_all_experiments_summary,
+    get_experiment_code,
+    get_experiment_output,
 )
 from comet_mcp.session import session_context
 
@@ -915,6 +917,126 @@ class TestGetAllExperimentsSummary:
 
         with pytest.raises(Exception) as exc_info:
             get_all_experiments_summary("smoke-test")
+
+        assert "API connection failed" in str(exc_info.value)
+
+
+class TestGetExperimentCode:
+    """Test cases for get_experiment_code tool."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        session_context.reset()
+        session_context.initialize()
+        # Clear cache to avoid test interference
+        from comet_mcp.tools import _clear_cache
+
+        _clear_cache()
+
+    @patch("comet_mcp.tools.get_comet_api")
+    def test_get_experiment_code_success(self, mock_get_api):
+        """Test successful retrieval of experiment code."""
+        mock_experiment = Mock()
+        mock_experiment.get_code.return_value = "print('Hello, World!')\n"
+
+        mock_api = Mock()
+        mock_api.get_experiment_by_key.return_value = mock_experiment
+        mock_get_api.return_value.__enter__.return_value = mock_api
+
+        result = get_experiment_code("exp123")
+
+        assert isinstance(result, dict)
+        assert "code" in result
+        assert result["code"] == "print('Hello, World!')\n"
+        mock_api.get_experiment_by_key.assert_called_once_with("exp123")
+
+    @patch("comet_mcp.tools.get_comet_api")
+    def test_get_experiment_code_empty(self, mock_get_api):
+        """Test retrieval when no code was logged."""
+        mock_experiment = Mock()
+        mock_experiment.get_code.return_value = ""
+
+        mock_api = Mock()
+        mock_api.get_experiment_by_key.return_value = mock_experiment
+        mock_get_api.return_value.__enter__.return_value = mock_api
+
+        result = get_experiment_code("exp123")
+
+        assert isinstance(result, dict)
+        assert "code" in result
+        assert result["code"] == ""
+
+
+class TestGetExperimentOutput:
+    """Test cases for get_experiment_output tool."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        session_context.reset()
+        session_context.initialize()
+        # Clear cache to avoid test interference
+        from comet_mcp.tools import _clear_cache
+
+        _clear_cache()
+
+    @patch("comet_mcp.tools.get_comet_api")
+    def test_get_experiment_output_success(self, mock_get_api):
+        """Test successful retrieval of experiment output."""
+        mock_experiment = Mock()
+        mock_experiment.get_output.return_value = "Epoch 1/10\nLoss: 0.5\nEpoch 2/10\nLoss: 0.3\n"
+
+        mock_api = Mock()
+        mock_api.get_experiment_by_key.return_value = mock_experiment
+        mock_get_api.return_value.__enter__.return_value = mock_api
+
+        result = get_experiment_output("exp123")
+
+        assert isinstance(result, dict)
+        assert "output" in result
+        assert result["output"] == "Epoch 1/10\nLoss: 0.5\nEpoch 2/10\nLoss: 0.3\n"
+        mock_api.get_experiment_by_key.assert_called_once_with("exp123")
+
+    @patch("comet_mcp.tools.get_comet_api")
+    def test_get_experiment_output_empty(self, mock_get_api):
+        """Test retrieval when no output was logged."""
+        mock_experiment = Mock()
+        mock_experiment.get_output.return_value = ""
+
+        mock_api = Mock()
+        mock_api.get_experiment_by_key.return_value = mock_experiment
+        mock_get_api.return_value.__enter__.return_value = mock_api
+
+        result = get_experiment_output("exp123")
+
+        assert isinstance(result, dict)
+        assert "output" in result
+        assert result["output"] == ""
+
+    @patch("comet_mcp.tools.get_comet_api")
+    def test_get_experiment_output_with_stderr(self, mock_get_api):
+        """Test retrieval of output including stderr."""
+        mock_experiment = Mock()
+        mock_output = "Training started...\nWarning: GPU not found\nTraining on CPU\nEpoch 1 complete\n"
+        mock_experiment.get_output.return_value = mock_output
+
+        mock_api = Mock()
+        mock_api.get_experiment_by_key.return_value = mock_experiment
+        mock_get_api.return_value.__enter__.return_value = mock_api
+
+        result = get_experiment_output("exp456")
+
+        assert isinstance(result, dict)
+        assert "output" in result
+        assert result["output"] == mock_output
+        assert "Warning: GPU not found" in result["output"]
+
+    @patch("comet_mcp.tools.get_comet_api")
+    def test_get_experiment_output_api_error(self, mock_get_api):
+        """Test handling of API errors."""
+        mock_get_api.side_effect = Exception("API connection failed")
+
+        with pytest.raises(Exception) as exc_info:
+            get_experiment_output("exp123")
 
         assert "API connection failed" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary

This PR adds a new MCP tool `get_experiment_output()` that allows users to retrieve the raw training logging (stdout/stderr) from experiments. This addresses a user request for accessing training output that was previously only available via the Python SDK.

## Changes

- ✨ **New Tool**: `get_experiment_output(experiment_id)` in `comet_mcp/tools.py`
  - Retrieves stdout/stderr output from experiments
  - Follows the same pattern as `get_experiment_code()`
  - Uses `experiment.get_output()` from the Comet ML SDK
  
- 🧪 **Tests**: Comprehensive unit tests in `tests/unit/test_tools.py`
  - Tests successful output retrieval
  - Tests empty output handling
  - Tests output with stderr
  - Tests API error handling
  
- 📚 **Documentation**: Updated `README.md` to list the new tool

## Implementation Details

The implementation is straightforward and follows the existing pattern:

```python
@_instrument_tool
def get_experiment_output(experiment_id: str) -> Dict[str, str]:
    """Get the raw training logging (stdout/stderr) for a specific experiment."""
    with get_comet_api() as api:
        experiment = api.get_experiment_by_key(experiment_id)
        return {"output": experiment.get_output()}
```

## Testing

All new tests pass:
```bash
COMET_API_KEY=dummy_key_for_testing .venv/bin/python -m pytest tests/unit/test_tools.py::TestGetExperimentOutput -v
# ============================= 4 passed in 3.52s ==============================
```

## Checklist

- [x] Implementation follows existing code patterns
- [x] Unit tests added and passing
- [x] Documentation updated
- [x] Tool is automatically registered via `@_instrument_tool` decorator
- [x] Telemetry/tracing support included
- [x] Error handling consistent with other tools