### PR TITLE
[OPIK-5828] Add asset tools and extensible asset handler plugin system

### DIFF
--- a/comet_mcp/asset_handlers/__init__.py
+++ b/comet_mcp/asset_handlers/__init__.py
@@ -1,0 +1,56 @@
+"""Asset handler registry and auto-discovery for Comet MCP.
+
+To add a new handler, drop a module into this package that defines:
+  MATCH_PATTERN: str   — fnmatch pattern matched against asset filenames
+  handle(content: bytes, asset_name: str) -> Dict[str, Any]
+"""
+
+import fnmatch
+import importlib
+import pkgutil
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+AssetHandlerFn = Callable[[bytes, str], Dict[str, Any]]
+
+_registry: List[Tuple[str, AssetHandlerFn]] = []
+_loaded = False
+
+
+def register_handler(pattern: str, handler: AssetHandlerFn) -> None:
+    """Register a handler function for assets whose names match *pattern*."""
+    _registry.append((pattern, handler))
+
+
+def get_handler(asset_name: str) -> Optional[AssetHandlerFn]:
+    """Return the first registered handler whose pattern matches *asset_name*."""
+    _ensure_loaded()
+    for pattern, handler in _registry:
+        if fnmatch.fnmatch(asset_name, pattern):
+            return handler
+    return None
+
+
+def _ensure_loaded() -> None:
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+    _discover_handlers()
+
+
+def _discover_handlers() -> None:
+    package_dir = Path(__file__).parent
+    for module_info in pkgutil.iter_modules([str(package_dir)]):
+        if module_info.name.startswith("_"):
+            continue
+        try:
+            module = importlib.import_module(
+                f"comet_mcp.asset_handlers.{module_info.name}"
+            )
+            pattern: Optional[str] = getattr(module, "MATCH_PATTERN", None)
+            handler: Optional[AssetHandlerFn] = getattr(module, "handle", None)
+            if pattern and handler and callable(handler):
+                register_handler(pattern, handler)
+        except Exception:
+            pass

--- a/comet_mcp/asset_handlers/hta.py
+++ b/comet_mcp/asset_handlers/hta.py
@@ -1,0 +1,102 @@
+"""HolisticTraceAnalysis handler for *_hta_results.json.gz assets.
+
+Install the optional dependency with: pip install comet-mcp[hta]
+"""
+
+import os
+import tempfile
+from typing import Any, Dict, List
+
+MATCH_PATTERN = "*_hta_results.json.gz"
+
+
+def handle(asset_content: bytes, asset_name: str) -> Dict[str, Any]:
+    """Analyze a PyTorch distributed trace asset and return a concise summary.
+
+    Returns temporal breakdown, communication/compute overlap, potential
+    stragglers, and the top GPU kernels by time — enough for an LLM to
+    diagnose performance issues without being overwhelmed by raw data.
+    """
+    try:
+        from hta.trace_analysis import TraceAnalysis  # type: ignore[import]
+    except ImportError:
+        return {
+            "asset_name": asset_name,
+            "error": (
+                "HolisticTraceAnalysis is not installed. "
+                "Install it with: pip install comet-mcp[hta]"
+            ),
+        }
+
+    with tempfile.NamedTemporaryFile(suffix=".json.gz", delete=False) as f:
+        f.write(asset_content)
+        tmp_path = f.name
+
+    try:
+        analyzer = TraceAnalysis(trace_files={0: tmp_path})
+        result: Dict[str, Any] = {"asset_name": asset_name}
+
+        result.update(_temporal_breakdown(analyzer))
+        result.update(_comm_comp_overlap(analyzer))
+        result.update(_stragglers(analyzer))
+        result.update(_top_kernels(analyzer))
+
+        return result
+    except Exception as e:
+        return {"asset_name": asset_name, "error": f"Analysis failed: {e}"}
+    finally:
+        os.unlink(tmp_path)
+
+
+def _temporal_breakdown(analyzer: Any) -> Dict[str, Any]:
+    try:
+        df = analyzer.get_temporal_breakdown(visualize=False)
+        return {
+            "num_ranks": len(df),
+            "temporal_breakdown": {
+                "mean_compute_pctg": _pct(df["compute_time_pctg"].mean()),
+                "mean_idle_pctg": _pct(df["idle_time_pctg"].mean()),
+                "mean_non_compute_pctg": _pct(df["non_compute_time_pctg"].mean()),
+            },
+        }
+    except Exception as e:
+        return {"temporal_breakdown": {"error": str(e)}}
+
+
+def _comm_comp_overlap(analyzer: Any) -> Dict[str, Any]:
+    try:
+        df = analyzer.get_comm_comp_overlap()
+        pcts: List[float] = df["comp_comm_overlap_pctg"].dropna().tolist()
+        if not pcts:
+            return {}
+        return {
+            "comm_comp_overlap": {
+                "min": _pct(min(pcts)),
+                "max": _pct(max(pcts)),
+                "mean": _pct(sum(pcts) / len(pcts)),
+            }
+        }
+    except Exception as e:
+        return {"comm_comp_overlap": {"error": str(e)}}
+
+
+def _stragglers(analyzer: Any) -> Dict[str, Any]:
+    try:
+        return {"potential_stragglers": analyzer.get_potential_stragglers()}
+    except Exception as e:
+        return {"potential_stragglers": {"error": str(e)}}
+
+
+def _top_kernels(analyzer: Any) -> Dict[str, Any]:
+    try:
+        _type_df, kernel_df = analyzer.get_gpu_kernel_breakdown(
+            visualize=False, num_kernels=5
+        )
+        want = [c for c in ["name", "sum", "percentage", "kernel_type"] if c in kernel_df.columns]
+        return {"top_kernels_by_time": kernel_df[want].head(5).to_dict(orient="records")}
+    except Exception as e:
+        return {"top_kernels_by_time": {"error": str(e)}}
+
+
+def _pct(value: Any) -> float:
+    return round(float(value), 3)

--- a/comet_mcp/tools.py
+++ b/comet_mcp/tools.py
@@ -1409,6 +1409,126 @@ def experiment_spreadsheet(
         }
 
 
+@_instrument_tool
+@cached(ttl_seconds=60)
+def get_experiment_assets(
+    experiment_id: str,
+    name_filter: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    List assets logged to a Comet experiment, optionally filtered by partial name.
+    Use this to discover what files have been logged — HTA traces, models, images,
+    or other artifacts. Pass name_filter to narrow results (e.g. "hta_results").
+
+    Args:
+        experiment_id: The ID of the experiment
+        name_filter: Optional substring to filter asset names (case-insensitive)
+
+    Returns:
+        Dictionary containing:
+        - experiment_id: The experiment ID
+        - assets: List of asset metadata with name, size, type, asset_id
+        - count: Number of matching assets
+    """
+    with get_comet_api() as api:
+        experiment = api.get_experiment_by_key(experiment_id)
+        if not experiment:
+            raise Exception(f"Experiment '{experiment_id}' not found.")
+
+        asset_list = experiment.get_asset_list(asset_type="all") or []
+
+        if name_filter:
+            filter_lower = name_filter.lower()
+            asset_list = [
+                a for a in asset_list
+                if filter_lower in (a.get("fileName") or "").lower()
+            ]
+
+        assets = [
+            {
+                "name": a.get("fileName", ""),
+                "size": a.get("fileSize", 0),
+                "type": a.get("type", ""),
+                "asset_id": a.get("assetId", ""),
+            }
+            for a in asset_list
+        ]
+
+        return {
+            "experiment_id": experiment_id,
+            "assets": assets,
+            "count": len(assets),
+        }
+
+
+@_instrument_tool
+def analyze_experiment_asset(
+    experiment_id: str,
+    name_filter: str,
+) -> Dict[str, Any]:
+    """
+    Download and analyze an experiment asset matched by partial name. Automatically
+    applies specialized analysis based on asset type — for example, running
+    HolisticTraceAnalysis on *_hta_results.json.gz files to diagnose GPU utilization,
+    communication bottlenecks, and training stragglers in distributed runs.
+
+    Use get_experiment_assets first to discover available asset names, then call
+    this tool with a name_filter that uniquely identifies the asset you want.
+
+    Args:
+        experiment_id: The ID of the experiment
+        name_filter: Substring to match against asset filenames (case-insensitive).
+                     The first matching asset will be downloaded and analyzed.
+
+    Returns:
+        For HTA trace assets: summary with temporal breakdown, comm/comp overlap,
+        potential stragglers, and top GPU kernels by time.
+        For unrecognized assets: basic metadata (name, size, type).
+    """
+    from comet_mcp.asset_handlers import get_handler
+
+    with get_comet_api() as api:
+        experiment = api.get_experiment_by_key(experiment_id)
+        if not experiment:
+            raise Exception(f"Experiment '{experiment_id}' not found.")
+
+        asset_list = experiment.get_asset_list(asset_type="all") or []
+        filter_lower = name_filter.lower()
+        matching = [
+            a for a in asset_list
+            if filter_lower in (a.get("fileName") or "").lower()
+        ]
+
+        if not matching:
+            return {
+                "error": f"No asset matching '{name_filter}' found.",
+                "available_assets": [a.get("fileName", "") for a in asset_list[:10]],
+            }
+
+        asset_meta = matching[0]
+        asset_name: str = asset_meta.get("fileName", "")
+        asset_id: str = asset_meta.get("assetId", "")
+
+        handler = get_handler(asset_name)
+        if handler is None:
+            return {
+                "asset_name": asset_name,
+                "asset_id": asset_id,
+                "size": asset_meta.get("fileSize", 0),
+                "type": asset_meta.get("type", ""),
+                "message": (
+                    "No specialized handler for this asset type. "
+                    "Raw metadata returned."
+                ),
+            }
+
+        content = experiment.get_asset(asset_id, return_type="binary")
+        if not isinstance(content, bytes):
+            return {"error": f"Unexpected content type for asset '{asset_name}'."}
+
+        return handler(content, asset_name)
+
+
 def _initialize():
     from comet_mcp.session import initialize_session
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
 ]
+hta = [
+    "HolisticTraceAnalysis>=0.1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/comet-ml/comet-mcp"
@@ -58,6 +61,7 @@ include = ["comet_mcp*"]
 
 [tool.setuptools.package-data]
 comet_mcp = ["*.py", "*.md", "*.txt"]
+"comet_mcp.asset_handlers" = ["*.py"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary

This PR introduces two new MCP tools for working with experiment assets, plus a lightweight plugin architecture that makes it easy to add specialized analysis for any asset type.

### New MCP tools

- **`get_experiment_assets`** — lists all assets logged to an experiment, with optional partial-name filtering. Useful for discovering what's available before fetching (e.g. `"hta_results"` to find HTA traces).
- **`analyze_experiment_asset`** — downloads an asset matched by partial name and routes it to a registered handler for deep analysis. Falls back to raw metadata for unrecognized types.

### Asset handler plugin system (`comet_mcp/asset_handlers/`)

Handlers are auto-discovered at runtime: drop any Python module into `comet_mcp/asset_handlers/` that defines `MATCH_PATTERN` (an fnmatch glob) and `handle(content: bytes, asset_name: str) -> dict`, and it will be registered automatically — no other changes required.

### HTA handler (`asset_handlers/hta.py`)

Ships the first handler, matching `*_hta_results.json.gz` assets logged via `exp.log_asset("..._hta_results.json.gz")`. It runs [HolisticTraceAnalysis](https://github.com/facebookresearch/HolisticTraceAnalysis) on the downloaded trace and returns a concise, LLM-friendly summary:

```json
{
  "asset_name": "run42_hta_results.json.gz",
  "num_ranks": 8,
  "temporal_breakdown": { "mean_compute_pctg": 0.71, "mean_idle_pctg": 0.12, ... },
  "comm_comp_overlap": { "min": 0.31, "max": 0.54, "mean": 0.42 },
  "potential_stragglers": [2, 5],
  "top_kernels_by_time": [{ "name": "volta_sgemm_...", "sum": 98000, ... }]
}
```

Rather than forwarding raw DataFrames, the handler summarizes each analysis into a handful of scalars — enough for an LLM to answer questions like "why is training slow?" or "which GPU is the bottleneck?" without context overflow. Drill-down (full per-rank tables) is straightforward to add as additional tools later.

HTA is an **optional dependency** — users who don't need it are unaffected:

```bash
pip install comet-mcp[hta]   # opt in
```

If HTA is not installed, `analyze_experiment_asset` returns a clear install instruction rather than raising an error.

## Test plan

- [ ] `get_experiment_assets(experiment_id)` returns all assets with correct metadata fields
- [ ] `get_experiment_assets(experiment_id, name_filter="hta_results")` filters correctly
- [ ] `analyze_experiment_asset` on an HTA asset returns the summary dict
- [ ] `analyze_experiment_asset` on a non-HTA asset returns raw metadata with a `message` field
- [ ] `analyze_experiment_asset` with HTA not installed returns an `error` field with install instructions
- [ ] Dropping a new `.py` file into `comet_mcp/asset_handlers/` with `MATCH_PATTERN` + `handle()` registers automatically on next import

🤖 Generated with [Claude Code](https://claude.com/claude-code)