### PR TITLE
Fix format_datetime timezone bug and list_experiments return type

### DIFF
--- a/comet_mcp/tools.py
+++ b/comet_mcp/tools.py
@@ -102,7 +102,7 @@ def list_experiments(
     page_size: Optional[int] = 10,
     sort_by: Optional[str] = None,
     sort_order: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+) -> Dict[str, Any]:
     """
     List recent experiments from Comet ML. Typically, don't show the
     user the experiment_id unless they ask to see it.
@@ -117,12 +117,16 @@ def list_experiments(
             Required when page, page_size, and sort_by are all specified.
 
     Returns:
-        List of dictionaries containing experiment details:
-        - id: Unique experiment identifier
-        - name: Human-readable experiment name
-        - status: Current experiment state (e.g., "running", "finished")
-        - created_at: Formatted timestamp when experiment was created
-        - description: Optional experiment description if available
+        Dictionary containing:
+        - workspace: The workspace the experiments were listed from
+        - project: The project the experiments were listed from
+        - experiments: List of dictionaries containing experiment details
+          (empty if no experiments match):
+            - id: Unique experiment identifier
+            - name: Human-readable experiment name
+            - status: Current experiment state (e.g., "running", "finished")
+            - created_at: Formatted timestamp when experiment was created
+            - description: Optional experiment description if available
     """
     with get_comet_api() as api:
         if workspace:
@@ -186,15 +190,12 @@ def list_experiments(
                 end_idx = start_idx + page_size
                 experiments = experiments[start_idx:end_idx]
 
-        if not experiments:
-            return []
-
-        result = {
+        result: Dict[str, Any] = {
             "workspace": target_workspace,
             "project": project_name,
             "experiments": [],
         }
-        for exp in experiments:
+        for exp in experiments or []:
             result["experiments"].append(
                 {
                     "id": exp.id,

--- a/comet_mcp/utils.py
+++ b/comet_mcp/utils.py
@@ -5,7 +5,7 @@ Utility module for MCP server with automatic parameter generation from Python fu
 
 import inspect
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Callable, Optional, Union
 from mcp import Tool
 
@@ -271,6 +271,11 @@ def format_datetime(dt) -> str:
     """
     Format a datetime object, timestamp, or other date-like object as a readable ISO string.
 
+    Timestamps are absolute instants (UTC epoch), and Comet server timestamps
+    are UTC, so the result is always rendered in UTC with an explicit offset
+    (e.g. "2024-01-01T12:00:00+00:00"). This keeps output unambiguous and
+    independent of the timezone the server happens to run in.
+
     Args:
         dt: The datetime object, timestamp (int/float), or other date-like object to format
 
@@ -280,8 +285,13 @@ def format_datetime(dt) -> str:
     if dt is None:
         return "Unknown"
 
-    # Handle datetime objects
+    # Handle datetime objects: normalize to UTC. Naive datetimes are assumed to
+    # already be UTC (as Comet server timestamps are).
     if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
         return dt.isoformat()
 
     # Handle Unix timestamps (int or float)
@@ -290,8 +300,8 @@ def format_datetime(dt) -> str:
             # Check if timestamp is in milliseconds (13 digits) or seconds (10 digits)
             if dt > 1e12:  # Likely milliseconds
                 dt = dt / 1000.0
-            # Convert Unix timestamp to datetime
-            dt_obj = datetime.fromtimestamp(dt)
+            # Convert Unix timestamp to datetime in UTC
+            dt_obj = datetime.fromtimestamp(dt, tz=timezone.utc)
             return dt_obj.isoformat()
         except (ValueError, OSError):
             # If timestamp conversion fails, return the raw value

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -74,7 +74,7 @@ class TestListExperiments:
         assert exp1["id"] == "exp1"
         assert exp1["name"] == "Test Experiment 1"
         assert exp1["status"] == "completed"
-        assert exp1["created_at"] == "2024-01-01T12:00:00"  # Original timestamp
+        assert exp1["created_at"] == "2024-01-01T12:00:00+00:00"  # UTC
         assert exp1["description"] == "Test description 1"
 
         # Verify second experiment
@@ -83,7 +83,7 @@ class TestListExperiments:
         assert exp2["id"] == "exp2"
         assert exp2["name"] == "Test Experiment 2"
         assert exp2["status"] == "running"
-        assert exp2["created_at"] == "2024-01-02T12:00:00"  # Original timestamp
+        assert exp2["created_at"] == "2024-01-02T12:00:00+00:00"  # UTC
         assert exp2["description"] is None
 
         # Verify API was called correctly (project_name defaults to "general" if None)
@@ -112,9 +112,10 @@ class TestListExperiments:
 
         result = list_experiments(workspace="test-workspace")
 
-        # When no experiments, function returns empty list
-        assert isinstance(result, list)
-        assert len(result) == 0
+        # When no experiments, function returns a dict with an empty list
+        assert isinstance(result, dict)
+        assert result["workspace"] == "test-workspace"
+        assert result["experiments"] == []
 
         # Verify API was called (project_name defaults to "general" if None)
         from comet_mcp.tools import SUPPORTS_PAGED_QUERIES
@@ -142,8 +143,8 @@ class TestListExperiments:
 
         result = list_experiments()
 
-        assert isinstance(result, list)
-        assert len(result) == 0
+        assert isinstance(result, dict)
+        assert result["experiments"] == []
 
     @patch("comet_mcp.tools.get_comet_api")
     def test_list_experiments_api_error(self, mock_get_api):
@@ -268,8 +269,8 @@ class TestGetExperimentDetails:
         assert result["id"] == "exp123"
         assert result["name"] == "Detailed Experiment"
         assert result["status"] == "completed"
-        assert result["created_at"] == "2024-01-01T12:00:00"
-        assert result["updated_at"] == "2024-01-02T12:00:00"
+        assert result["created_at"] == "2024-01-01T12:00:00+00:00"
+        assert result["updated_at"] == "2024-01-02T12:00:00+00:00"
         assert result["description"] == "Detailed description"
 
         # Verify metrics
@@ -875,16 +876,15 @@ class TestGetAllExperimentsSummary:
         assert exp1["id"] == "exp1"
         assert exp1["name"] == "Project Experiment 1"
         assert exp1["status"] == "finished"
-        # Timestamps render in the local timezone; compute the expectation the
-        # same way the tool does so the test is timezone-independent.
-        assert exp1["created_at"] == datetime.fromtimestamp(1704110400).isoformat()
+        # Timestamps always render in UTC with an explicit offset.
+        assert exp1["created_at"] == "2024-01-01T12:00:00+00:00"
 
         # Verify second experiment
         exp2 = result["experiments"][1]
         assert exp2["id"] == "exp2"
         assert exp2["name"] == "Project Experiment 2"
         assert exp2["status"] == "running"
-        assert exp2["created_at"] == datetime.fromtimestamp(1704196800).isoformat()
+        assert exp2["created_at"] == "2024-01-02T12:00:00+00:00"
 
         # Verify API was called correctly
         mock_api._get_project_experiments.assert_called_once_with(
@@ -1114,8 +1114,8 @@ class TestUpdatedListExperiments:
 
         result = list_experiments(workspace="test-workspace", project_name="smoke-test")
 
-        assert isinstance(result, list)
-        assert len(result) == 0
+        assert isinstance(result, dict)
+        assert result["experiments"] == []
         mock_api.get_experiments.assert_called_once_with(
             workspace="test-workspace",
             project_name="smoke-test",


### PR DESCRIPTION
## Summary

Fixes the two latent product bugs flagged in #14.

### 1. `format_datetime` rendered local time without an offset
It converted epoch timestamps with `datetime.fromtimestamp(dt)` (no tz), so the same instant printed differently depending on the **server's** timezone, and the ISO string had no offset (ambiguous). Now everything is normalized to **UTC with an explicit offset**:

- Epoch ints/floats → `datetime.fromtimestamp(dt, tz=timezone.utc)`.
- `datetime` objects → naive ones are assumed UTC (Comet server timestamps are UTC); aware ones are converted via `astimezone(utc)`.
- Output example: `2024-01-01T12:00:00+00:00`.

### 2. `list_experiments` had an inconsistent return type
It returned a bare `[]` when nothing matched but a dict (`{workspace, project, experiments}`) otherwise — callers had to handle both. It now **always** returns the dict, with an empty `experiments` list when nothing matches. Return annotation (`Dict[str, Any]`) and docstring updated. No internal callers depend on the old shape; it's only exposed as an MCP tool.

Tests updated to assert the UTC-offset timestamps and the consistent dict shape. All unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)